### PR TITLE
Fix BUILD dep for vz_line_chart

### DIFF
--- a/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
+++ b/tensorboard/plugins/debugger/tf_debugger_dashboard/BUILD
@@ -22,9 +22,9 @@ ts_web_library(
         "//tensorboard/components/tf_paginated_view",
         "//tensorboard/components/tf_runs_selector",
         "//tensorboard/components/tf_storage",
+        "//tensorboard/components/vz_line_chart",  # TODO(cais): Use to draw data lines.
         "//tensorboard/plugins/graph/tf_graph",
         "//tensorboard/plugins/graph/tf_graph_loader",
-        "//tensorboard/plugins/scalar/vz_line_chart",  # TODO(cais): Use to draw data lines.
         "@org_polymer_iron_collapse",
         "@org_polymer_iron_icon",
         "@org_polymer_paper_button",


### PR DESCRIPTION
It used to be stored under plugins/vz_line_chart. A recent change (#422) generalized vz_line_chart, so it is now stored under components.